### PR TITLE
Add CIF/mmCIF file format support

### DIFF
--- a/src/graphrelax/structure_io.py
+++ b/src/graphrelax/structure_io.py
@@ -1,0 +1,193 @@
+"""Unified structure I/O utilities for PDB and CIF formats."""
+
+import io
+import logging
+import tempfile
+from enum import Enum
+from pathlib import Path
+
+from Bio.PDB import MMCIFIO, PDBIO, MMCIFParser, PDBParser
+
+logger = logging.getLogger(__name__)
+
+
+class StructureFormat(Enum):
+    """Supported structure file formats."""
+
+    PDB = "pdb"
+    CIF = "cif"
+
+
+def detect_format(path: Path) -> StructureFormat:
+    """
+    Auto-detect structure format from file extension.
+
+    Args:
+        path: Path to structure file
+
+    Returns:
+        StructureFormat enum value
+
+    Raises:
+        ValueError: If extension is not recognized
+    """
+    suffix = path.suffix.lower()
+    if suffix == ".pdb":
+        return StructureFormat.PDB
+    elif suffix in (".cif", ".mmcif"):
+        return StructureFormat.CIF
+    else:
+        raise ValueError(
+            f"Unknown structure format for extension '{suffix}'. "
+            "Supported: .pdb, .cif, .mmcif"
+        )
+
+
+def read_structure(path: Path) -> str:
+    """
+    Read structure file contents as string.
+
+    Args:
+        path: Path to structure file
+
+    Returns:
+        File contents as string
+    """
+    with open(path) as f:
+        return f.read()
+
+
+def write_structure(content: str, path: Path, fmt: StructureFormat = None):
+    """
+    Write structure string to file.
+
+    Args:
+        content: Structure content as string
+        path: Output file path
+        fmt: Target format (auto-detected from path if not provided)
+    """
+    if fmt is None:
+        fmt = detect_format(path)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+    logger.info(f"Saved structure to {path}")
+
+
+def convert_pdb_to_cif(pdb_string: str) -> str:
+    """
+    Convert PDB format string to CIF format string.
+
+    Args:
+        pdb_string: Structure in PDB format
+
+    Returns:
+        Structure in CIF format
+    """
+    parser = PDBParser(QUIET=True)
+    handle = io.StringIO(pdb_string)
+    structure = parser.get_structure("structure", handle)
+
+    cif_io = MMCIFIO()
+    cif_io.set_structure(structure)
+
+    output = io.StringIO()
+    cif_io.save(output)
+    return output.getvalue()
+
+
+def convert_cif_to_pdb(cif_string: str) -> str:
+    """
+    Convert CIF format string to PDB format string.
+
+    Args:
+        cif_string: Structure in CIF format
+
+    Returns:
+        Structure in PDB format
+    """
+    # MMCIFParser requires a file path, so use temp file
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".cif", delete=False
+    ) as tmp:
+        tmp.write(cif_string)
+        tmp_path = tmp.name
+
+    try:
+        parser = MMCIFParser(QUIET=True)
+        structure = parser.get_structure("structure", tmp_path)
+
+        pdb_io = PDBIO()
+        pdb_io.set_structure(structure)
+
+        output = io.StringIO()
+        pdb_io.save(output)
+        return output.getvalue()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def ensure_pdb_format(content: str, source_path: Path) -> str:
+    """
+    Ensure structure content is in PDB format.
+
+    If source is CIF, converts to PDB. Otherwise returns as-is.
+
+    Args:
+        content: Structure content string
+        source_path: Original file path (for format detection)
+
+    Returns:
+        Structure in PDB format
+    """
+    fmt = detect_format(source_path)
+    if fmt == StructureFormat.CIF:
+        logger.debug("Converting CIF to PDB for internal processing")
+        return convert_cif_to_pdb(content)
+    return content
+
+
+def convert_to_format(pdb_string: str, target_format: StructureFormat) -> str:
+    """
+    Convert PDB string to target format.
+
+    Args:
+        pdb_string: Structure in PDB format
+        target_format: Desired output format
+
+    Returns:
+        Structure in target format
+    """
+    if target_format == StructureFormat.PDB:
+        return pdb_string
+    elif target_format == StructureFormat.CIF:
+        return convert_pdb_to_cif(pdb_string)
+    else:
+        raise ValueError(f"Unknown target format: {target_format}")
+
+
+def get_output_format(
+    input_path: Path,
+    output_path: Path,
+) -> StructureFormat:
+    """
+    Determine output format based on output path extension.
+
+    Falls back to input format if output path has no recognized extension.
+
+    Args:
+        input_path: Input file path
+        output_path: Output file path
+
+    Returns:
+        StructureFormat for output
+    """
+    # Try to detect from output path extension
+    try:
+        return detect_format(output_path)
+    except ValueError:
+        pass
+
+    # Fall back to input format
+    return detect_format(input_path)

--- a/tests/test_structure_io.py
+++ b/tests/test_structure_io.py
@@ -1,0 +1,233 @@
+"""Tests for graphrelax.structure_io module."""
+
+import pytest
+
+from graphrelax.structure_io import (
+    StructureFormat,
+    convert_cif_to_pdb,
+    convert_pdb_to_cif,
+    convert_to_format,
+    detect_format,
+    ensure_pdb_format,
+    get_output_format,
+    read_structure,
+    write_structure,
+)
+
+
+class TestDetectFormat:
+    """Tests for detect_format function."""
+
+    def test_detect_pdb_format(self, tmp_path):
+        """Test detection of PDB format."""
+        path = tmp_path / "test.pdb"
+        assert detect_format(path) == StructureFormat.PDB
+
+    def test_detect_cif_format(self, tmp_path):
+        """Test detection of CIF format."""
+        path = tmp_path / "test.cif"
+        assert detect_format(path) == StructureFormat.CIF
+
+    def test_detect_mmcif_format(self, tmp_path):
+        """Test detection of mmCIF format."""
+        path = tmp_path / "test.mmcif"
+        assert detect_format(path) == StructureFormat.CIF
+
+    def test_detect_uppercase_extension(self, tmp_path):
+        """Test detection handles uppercase extensions."""
+        path = tmp_path / "test.PDB"
+        assert detect_format(path) == StructureFormat.PDB
+
+        path = tmp_path / "test.CIF"
+        assert detect_format(path) == StructureFormat.CIF
+
+    def test_unknown_format_raises(self, tmp_path):
+        """Test that unknown extension raises ValueError."""
+        path = tmp_path / "test.xyz"
+        with pytest.raises(ValueError, match="Unknown structure format"):
+            detect_format(path)
+
+    def test_no_extension_raises(self, tmp_path):
+        """Test that missing extension raises ValueError."""
+        path = tmp_path / "testfile"
+        with pytest.raises(ValueError, match="Unknown structure format"):
+            detect_format(path)
+
+
+class TestReadStructure:
+    """Tests for read_structure function."""
+
+    def test_read_pdb_file(self, tmp_path, small_peptide_pdb_string):
+        """Test reading PDB file."""
+        path = tmp_path / "test.pdb"
+        path.write_text(small_peptide_pdb_string)
+
+        content = read_structure(path)
+        assert content == small_peptide_pdb_string
+
+    def test_read_preserves_newlines(self, tmp_path):
+        """Test that newlines are preserved."""
+        content = "ATOM      1\nATOM      2\n"
+        path = tmp_path / "test.pdb"
+        path.write_text(content)
+
+        result = read_structure(path)
+        assert result == content
+
+
+class TestWriteStructure:
+    """Tests for write_structure function."""
+
+    def test_write_pdb_format(self, tmp_path):
+        """Test writing PDB format."""
+        content = "ATOM      1  N   ALA A   1"
+        path = tmp_path / "output.pdb"
+
+        write_structure(content, path, StructureFormat.PDB)
+
+        assert path.exists()
+        assert path.read_text() == content
+
+    def test_write_creates_parent_dirs(self, tmp_path):
+        """Test that parent directories are created."""
+        content = "ATOM      1  N   ALA A   1"
+        path = tmp_path / "subdir" / "nested" / "output.pdb"
+
+        write_structure(content, path)
+
+        assert path.exists()
+        assert path.read_text() == content
+
+    def test_write_auto_detect_format(self, tmp_path):
+        """Test format auto-detection from path."""
+        content = "ATOM      1  N   ALA A   1"
+        path = tmp_path / "output.pdb"
+
+        # Should not raise even without explicit format
+        write_structure(content, path)
+        assert path.exists()
+
+
+class TestConversion:
+    """Tests for format conversion functions."""
+
+    def test_pdb_to_cif_conversion(self, small_peptide_pdb_string):
+        """Test converting PDB to CIF format."""
+        cif_string = convert_pdb_to_cif(small_peptide_pdb_string)
+
+        # CIF files start with data_ block
+        assert cif_string.startswith("data_")
+        # Should contain atom_site loop
+        assert "_atom_site" in cif_string
+
+    def test_cif_to_pdb_conversion(self, small_peptide_pdb_string):
+        """Test converting CIF to PDB format."""
+        # First convert to CIF
+        cif_string = convert_pdb_to_cif(small_peptide_pdb_string)
+
+        # Then convert back to PDB
+        pdb_string = convert_cif_to_pdb(cif_string)
+
+        # Should have ATOM records
+        assert "ATOM" in pdb_string
+
+    def test_roundtrip_preserves_atoms(self, small_peptide_pdb_string):
+        """Test that roundtrip conversion preserves atom count."""
+        # Count atoms in original
+        original_atoms = len(
+            [
+                line
+                for line in small_peptide_pdb_string.splitlines()
+                if line.startswith("ATOM")
+            ]
+        )
+
+        # Roundtrip: PDB -> CIF -> PDB
+        cif_string = convert_pdb_to_cif(small_peptide_pdb_string)
+        pdb_string = convert_cif_to_pdb(cif_string)
+
+        # Count atoms after roundtrip
+        final_atoms = len(
+            [
+                line
+                for line in pdb_string.splitlines()
+                if line.startswith("ATOM")
+            ]
+        )
+
+        assert final_atoms == original_atoms
+
+    def test_convert_to_format_pdb(self, small_peptide_pdb_string):
+        """Test convert_to_format with PDB target."""
+        result = convert_to_format(
+            small_peptide_pdb_string, StructureFormat.PDB
+        )
+        # Should return unchanged
+        assert result == small_peptide_pdb_string
+
+    def test_convert_to_format_cif(self, small_peptide_pdb_string):
+        """Test convert_to_format with CIF target."""
+        result = convert_to_format(
+            small_peptide_pdb_string, StructureFormat.CIF
+        )
+        assert result.startswith("data_")
+
+
+class TestEnsurePdbFormat:
+    """Tests for ensure_pdb_format function."""
+
+    def test_pdb_input_unchanged(self, tmp_path, small_peptide_pdb_string):
+        """Test that PDB input is returned unchanged."""
+        path = tmp_path / "test.pdb"
+        path.write_text(small_peptide_pdb_string)
+
+        result = ensure_pdb_format(small_peptide_pdb_string, path)
+        assert result == small_peptide_pdb_string
+
+    def test_cif_input_converted(self, tmp_path, small_peptide_pdb_string):
+        """Test that CIF input is converted to PDB."""
+        # Create CIF content
+        cif_string = convert_pdb_to_cif(small_peptide_pdb_string)
+        path = tmp_path / "test.cif"
+        path.write_text(cif_string)
+
+        result = ensure_pdb_format(cif_string, path)
+        # Should be PDB format now
+        assert "ATOM" in result
+        assert not result.startswith("data_")
+
+
+class TestGetOutputFormat:
+    """Tests for get_output_format function."""
+
+    def test_uses_output_path_extension(self, tmp_path):
+        """Test that output path extension determines format."""
+        input_path = tmp_path / "input.pdb"
+        output_path = tmp_path / "output.cif"
+
+        result = get_output_format(input_path, output_path)
+        assert result == StructureFormat.CIF
+
+    def test_pdb_output_extension(self, tmp_path):
+        """Test PDB output extension."""
+        input_path = tmp_path / "input.cif"
+        output_path = tmp_path / "output.pdb"
+
+        result = get_output_format(input_path, output_path)
+        assert result == StructureFormat.PDB
+
+    def test_falls_back_to_input_format(self, tmp_path):
+        """Test fallback to input format when output has no extension."""
+        input_path = tmp_path / "input.cif"
+        output_path = tmp_path / "output"  # No extension
+
+        result = get_output_format(input_path, output_path)
+        assert result == StructureFormat.CIF
+
+    def test_same_format_preserved(self, tmp_path):
+        """Test same format is preserved."""
+        input_path = tmp_path / "input.pdb"
+        output_path = tmp_path / "output.pdb"
+
+        result = get_output_format(input_path, output_path)
+        assert result == StructureFormat.PDB


### PR DESCRIPTION
- Add structure_io.py module with format detection and PDB/CIF conversion
- Support CIF input files (auto-converted to PDB internally for processing)
- Support CIF output files (auto-detected from output path extension)
- Update utils.py with CIF-aware water removal
- Update pipeline.py to track input/output formats
- Update cli.py with CIF input validation and format-aware ligand detection
- Add comprehensive unit tests for structure_io module
- Add CIF integration tests for pipeline
- Add CIF test fixtures (small_peptide_cif, ubiquitin_cif)