### PR TITLE
Fix energy breakdown simulation by creating new integrator

### DIFF
--- a/src/graphrelax/relaxer.py
+++ b/src/graphrelax/relaxer.py
@@ -449,7 +449,9 @@ class Relaxer:
                 # Set this force to group i
                 force.setForceGroup(i)
 
-            # Recreate simulation with force groups
+            # Recreate simulation with force groups (need new integrator since
+            # the previous one is already bound to a context)
+            integrator = openmm.LangevinIntegrator(0, 0.01, 0.0)
             simulation = openmm_app.Simulation(
                 pdb.topology, system, integrator, platform
             )


### PR DESCRIPTION
## Summary
Fixed a bug in `get_energy_breakdown()` where the simulation was being recreated with a stale integrator that was already bound to a previous context, causing errors.

## Changes
- Create a fresh `LangevinIntegrator` instance before recreating the simulation with force groups
- Added explanatory comment clarifying why a new integrator is necessary

## Details
When recreating a simulation with force groups enabled, OpenMM requires a new integrator instance because the previous integrator is already bound to the old simulation's context. Reusing the same integrator object would cause context binding conflicts. This fix ensures each simulation gets its own independent integrator.